### PR TITLE
Working database-bound prefix

### DIFF
--- a/bin/marx.dart
+++ b/bin/marx.dart
@@ -53,6 +53,6 @@ Future<String> prefixHandler(Message msg) async {
 
 void onGuildCreate(GuildCreateEvent event) async {
   await database.connection.query(
-      'INSERT INTO guilds (id) VALUES (@id) ON CONFLICT DO NOTHING;',
-      substitutionValues: {'id': event.guild.id.id});
+      'INSERT INTO guilds (id, prefix) VALUES (@id, @prefix) ON CONFLICT DO NOTHING;',
+      substitutionValues: {'id': event.guild.id.id, 'prefix': config.prefix});
 }

--- a/lib/migrate.dart
+++ b/lib/migrate.dart
@@ -3,16 +3,13 @@ import 'package:marx/database.dart';
 
 Database database = Database();
 
-void main() async {
-  await database.connect();
-  print('Migrating database to the latest revision..');
-
+void migrate() async {
   var dir = Directory('./migrations');
   await dir
       .list(recursive: false, followLinks: false)
       .listen((FileSystemEntity entity) async {
     var fileName =
-        entity.path.split('/').last.split('\\').last.replaceFirst('.sql', '');
+    entity.path.split('/').last.split('\\').last.replaceFirst('.sql', '');
     var response = await database.connection.query(
         "SELECT EXISTS( SELECT 1 FROM information_schema.tables WHERE table_name = 'migrations' and table_schema='public');");
     var migrated_once = false;
@@ -36,7 +33,6 @@ void main() async {
     if (entity is File) contents = entity.readAsStringSync();
 
     if (contents != null) {
-      print('migrating ${fileName}');
       await database.connection.execute(contents);
       await database.connection.query(
           'INSERT INTO migrations (migration) VALUES (@migration)',


### PR DESCRIPTION
Add the ability for guilds to have custom prefixes that trigger the bot based on the database. This is incredibly bad right now without #9 however when that is implemented this will be much more efficient.